### PR TITLE
Update PLSS2LL.R

### DIFF
--- a/R/PLSS2LL.R
+++ b/R/PLSS2LL.R
@@ -56,7 +56,7 @@ formatPLSS <- function(p, type='SN') {
     p.r <- paste0(p.r, collapse = '0')
     
     # add 'SN to section number and pad single digit section numbers
-    p.s <- ifelse(as.numeric(p$s[i] > 9), paste0('SN', p$s[i]), paste0('SN', 0, p$s[i]))
+    p.s <- ifelse(as.numeric(p$s[i] > 9), paste0('SN', p$s[i]), paste0('SN', 0, as.numeric(p$s[i])))
     #p.s <- paste0('SN', p$s[i])
     
     # replace NA -> '' IN Q and QQ sections


### PR DESCRIPTION
A previous change added the first "as.numeric" in row 59, because when p$s was coded as a string, the conditional was returning erroneously. For x < 90, if x were coded as character (with or without a leading zero), x > 9 is FALSE. This meant that "04" got padded as well, resulting in a longer eventual plssid string. Testing it on a few coordinates, this extra padding can actually change the results from PLSS2LL. By adding the second "as.numeric" condition, the padding is done correctly regardless if p$s is character or numeric.